### PR TITLE
Remove restriction to version 6

### DIFF
--- a/multiline-string/src/main/java/org/adrianwalker/multilinestring/EcjMultilineProcessor.java
+++ b/multiline-string/src/main/java/org/adrianwalker/multilinestring/EcjMultilineProcessor.java
@@ -18,7 +18,6 @@ import org.eclipse.jdt.internal.compiler.ast.StringLiteral;
 import org.eclipse.jdt.internal.compiler.lookup.FieldBinding;
 
 @SupportedAnnotationTypes({"org.adrianwalker.multilinestring.Multiline"})
-@SupportedSourceVersion(SourceVersion.RELEASE_6)
 public final class EcjMultilineProcessor extends AbstractProcessor {
 
 	private Elements elementUtils;

--- a/multiline-string/src/main/java/org/adrianwalker/multilinestring/JavacMultilineProcessor.java
+++ b/multiline-string/src/main/java/org/adrianwalker/multilinestring/JavacMultilineProcessor.java
@@ -17,7 +17,6 @@ import com.sun.tools.javac.tree.JCTree.JCVariableDecl;
 import com.sun.tools.javac.tree.TreeMaker;
 
 @SupportedAnnotationTypes({"org.adrianwalker.multilinestring.Multiline"})
-@SupportedSourceVersion(SourceVersion.RELEASE_6)
 public final class JavacMultilineProcessor extends AbstractProcessor {
 
 	private JavacElements elementUtils;

--- a/multiline-string/src/main/java/org/adrianwalker/multilinestring/MultilineProcessor.java
+++ b/multiline-string/src/main/java/org/adrianwalker/multilinestring/MultilineProcessor.java
@@ -12,7 +12,6 @@ import javax.lang.model.SourceVersion;
 import javax.lang.model.element.TypeElement;
 
 @SupportedAnnotationTypes({"org.adrianwalker.multilinestring.Multiline"})
-@SupportedSourceVersion(SourceVersion.RELEASE_6)
 public final class MultilineProcessor extends AbstractProcessor {
   private Processor delegator = null;
   


### PR DESCRIPTION
The @SupportedSourceVersion(SourceVersion.RELEASE_6) tag was causing a 
warning when used in java 7 but everytyhing worked fine.

[javac] warning: Supported source version 'RELEASE_6' from annotation
processor 'org.adrianwalker.multilinestring.MultilineProcessor' less
than -source '1.7'

There are other possible solutions, see http://stackoverflow.com/questions/8185331/forward-compatible-java-6-annotation-processor-and-supportedsourceversion  and https://blogs.oracle.com/darcy/entry/annotation_processor_sourceversion but this seemed to be the simplest since it's such a simple annotation that is not likely to change with versions of the language
