### PR TITLE
Fix for eclipse 4.6

### DIFF
--- a/multiline-string/src/main/java/org/adrianwalker/multilinestring/StringProcessor.java
+++ b/multiline-string/src/main/java/org/adrianwalker/multilinestring/StringProcessor.java
@@ -28,7 +28,10 @@ public class StringProcessor
 				}
 				if(annotation.mergeLines() && buf.length()>0)
 				{
-					buf.append(annotation.mergeChar());
+					if(annotation.mergeChar() != '\0')
+					{
+						buf.append(annotation.mergeChar());
+					}
 				}
 				buf.append(line);
 				if(!annotation.mergeLines())


### PR DESCRIPTION
This allows multiline to work in eclipse 4.6. They changed the classloading so it does not expose the internal classes , we created a custom classloader that can see the internal classes and the mutlline class 